### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,5 +1,10 @@
 name: first-interaction
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 on:
   issues:
     types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/K0lin/Discord-Ticketing-Bot/security/code-scanning/2](https://github.com/K0lin/Discord-Ticketing-Bot/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow interacts with issues and pull requests, it needs `issues: write` and `pull-requests: write`. Additionally, it requires `contents: read` for basic repository access. These permissions will be added at the root of the workflow file to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
